### PR TITLE
fix(#20): do not throw wrapped error

### DIFF
--- a/deps.edn
+++ b/deps.edn
@@ -4,12 +4,21 @@
 
  :deps
  {funcool/promesa {:mvn/version "9.0.489"}
+  org.clojure/tools.logging {:mvn/version "1.2.4"}
   metosin/malli {:mvn/version "0.9.2"}}
 
  :aliases
  {:dev {:extra-paths ["test"]
         :extra-deps {thheller/shadow-cljs {:mvn/version "2.19.5"}
-                     lambdaisland/kaocha {:mvn/version "1.70.1086"}}}
+                     lambdaisland/kaocha {:mvn/version "1.70.1086"}
+                     ;; pipe other logging facades to slf4j
+                     org.slf4j/jul-to-slf4j {:mvn/version "1.7.36"}
+                     org.slf4j/jcl-over-slf4j {:mvn/version "1.7.36"}
+                     org.slf4j/log4j-over-slf4j {:mvn/version "1.7.36"}
+                     org.slf4j/osgi-over-slf4j {:mvn/version "1.7.36"}
+                     ch.qos.logback/logback-classic {:mvn/version "1.2.3"}
+                     org.clojure/tools.logging {:mvn/version "1.2.4"}}
+        :jvm-opts ["-Dclojure.tools.logging.factory=clojure.tools.logging.impl/slf4j-factory"]}
 
   :test {:extra-paths ["test"]
          :extra-deps {io.github.cognitect-labs/test-runner

--- a/repl_sessions/failures.clj
+++ b/repl_sessions/failures.clj
@@ -1,0 +1,29 @@
+(ns failures
+  (:require [k16.gx.beta.system :as gx.system]))
+
+(defn start-1 [_]
+  (let [a 10
+        e 0]
+    (/ a e)))
+
+(defn stop-1 [_] :stopped)
+
+(def parent-component {:gx/start {:gx/processor start-1}
+                       :gx/stop {:gx/processor stop-1}})
+
+(def graph {:config {:foo {:bar "something"}}
+            :parent {:gx/component 'failures/parent-component
+                     :gx/props '(gx/ref :config)}
+            :child {:foo 1
+                    :paren-data '(gx/ref :parent)}})
+
+(def system_name ::sys)
+
+(comment
+  (gx.system/register! system_name {:graph graph})
+  @(gx.system/signal! system_name :gx/start)
+  (print (gx.system/failures-humanized system_name))
+  (gx.system/failed-nodes system_name)
+  (:exception (first (:causes (last (gx.system/failures system_name)))))
+  (:internal-data (first (:failures (ex-data (.getCause *e)))))
+  (first (gx.system/failures system_name)))

--- a/src/k16/gx/beta/errors.cljc
+++ b/src/k16/gx/beta/errors.cljc
@@ -69,18 +69,19 @@
   [& token-pairs]
   (assert (even? (count token-pairs))
           "tokenize accepts only even number of forms")
-  (->> token-pairs
-       (map stringify)
-       (partition 2)
-       (filter (comp seq second))
-       (map (fn [[a b]] [a (str "'" b "'")]))
-       (interpose ", ")
-       (flatten)
-       (apply str)))
+  (apply str (transduce (comp
+                         (map stringify)
+                         (partition-all 2)
+                         (filter (comp seq second))
+                         (map (fn [[a b]] [a (str "'" b "'")]))
+                         (interpose ", "))
+                        (completing conj flatten)
+                        token-pairs)))
 
 (defn- cause->str
-  [{:keys [title data exception]}]
-  (str "cause(" title " = " data "): " (gather-error-messages exception)))
+  [{:keys [data exception]}]
+  (str "cause" (when data (str "(data = " data ")")) ": "
+       (gather-error-messages exception)))
 
 (defn humanize-error
   [{:keys [node-key signal-key message causes]} & rest-of-error]

--- a/src/k16/gx/beta/system.cljc
+++ b/src/k16/gx/beta/system.cljc
@@ -71,7 +71,7 @@
   (let [normalized (gx/normalize gx-map)]
     (swap! registry* assoc system-name normalized)
     (if-let [failures (seq (:failures normalized))]
-      (do (#?(:clj log/error :cljs js/console.log)
+      (do (#?(:clj log/error :cljs js/console.error)
            (str "Normalize error\n" (gx.errors/humanize-all failures)))
           (throw-root-exception! failures))
       normalized)))
@@ -98,7 +98,7 @@
          (p/then (fn [g]
                    (swap! registry* assoc system-name g)
                    (if-let [failures (:failures g)]
-                     (do (#?(:clj log/error :cljs js/console.log)
+                     (do (#?(:clj log/error :cljs js/console.error)
                           (str "Signal failed!\n"
                                (gx.errors/humanize-all failures)))
                          (throw-root-exception! failures))

--- a/src/k16/gx/beta/system.cljc
+++ b/src/k16/gx/beta/system.cljc
@@ -18,7 +18,7 @@
         {:keys [exception] :as root-cause} (first causes)]
     (cond
       exception (throw exception)
-      :else (throw (ex-info message root-cause)))))
+      :else (throw (ex-info message {:failures failures})))))
 
 (defn states
   "Gets list of states of the graph as map.
@@ -71,7 +71,7 @@
   (let [normalized (gx/normalize gx-map)]
     (swap! registry* assoc system-name normalized)
     (if-let [failures (seq (:failures normalized))]
-      (do (print (str "Normalize error\n" (gx.errors/humanize-all failures)))
+      (do (log/error (str "Normalize error\n" (gx.errors/humanize-all failures)))
           (throw-root-exception! failures))
       normalized)))
 

--- a/test/k16/gx/beta/system_test.cljc
+++ b/test/k16/gx/beta/system_test.cljc
@@ -70,4 +70,3 @@
                 :signal-key :gx/stop
                 :causes []}]}
              (ex-data err))))))
-


### PR DESCRIPTION
gx.system now throws a root exception instead of a wrapped one + it logs humanized error message which can be suppressed by filtering gx namespace.