### PR TITLE
fix(resolve-symbol): pass through non symbols

### DIFF
--- a/src/k16/gx/beta/core.cljc
+++ b/src/k16/gx/beta/core.cljc
@@ -326,8 +326,8 @@
                       (with-err-ctx err-ctx
                         (if (fn? resolved-props-fn)
                           (run-props-fn resolved-props-fn dep-nodes-vals)
-                          (impl/postwalk-evaluate 
-                            dep-nodes-vals resolved-props props)))
+                          (impl/postwalk-evaluate
+                           dep-nodes-vals resolved-props props)))
                       validate-error (with-err-ctx err-ctx
                                        (validate-props props-schema props-result))
                       [error result] (when-not validate-error

--- a/src/k16/gx/beta/impl.cljc
+++ b/src/k16/gx/beta/impl.cljc
@@ -181,7 +181,7 @@
 
 (defn resolve-symbol
   [sym]
-  (when (symbol? sym)
+  (if (symbol? sym)
     (if-let [nss #?(:cljs (namespace-symbol sym)
                     :clj (try
                            (some->> sym
@@ -195,7 +195,8 @@
                                :exception e}))))]
       nss
       (gx.err/add-err-cause {:title :symbol-cannot-be-resolved
-                             :data sym}))))
+                             :data sym}))
+    sym))
 
 (defn form->runnable [form-def]
   (let [props* (atom #{})


### PR DESCRIPTION
this PR makes symbol resolution consistent in all levels of graph evaluation, basically, it passes through a value if it is not a symbol, before - returned nil.