### PR TITLE
Add timeouts to component processors

### DIFF
--- a/src/k16/gx/beta/core.cljc
+++ b/src/k16/gx/beta/core.cljc
@@ -260,7 +260,7 @@
      (try
        [nil @(p/timeout (p/vthread @(p/do (processor arg-map))) timeout)]
        (catch Throwable e
-         [(wrap-error (or (ex-cause e) e) arg-map) nil]))))
+         [(wrap-error (gx.err/get-real-cause e) arg-map) nil]))))
 
 #?(:cljs
    (defn- run-processor

--- a/src/k16/gx/beta/core.cljc
+++ b/src/k16/gx/beta/core.cljc
@@ -256,18 +256,19 @@
 
 #?(:clj
    (defn- run-processor
-     [processor arg-map]
+     [processor arg-map timeout]
      (try
-       [nil @(p/do (processor arg-map))]
+       [nil @(p/timeout (p/vthread @(p/do (processor arg-map))) timeout)]
        (catch Throwable e
          [(wrap-error (or (ex-cause e) e) arg-map) nil]))))
 
 #?(:cljs
    (defn- run-processor
      "CLJS version with error context propagation"
-     [processor arg-map err-ctx]
+     [processor arg-map err-ctx timeout]
      (try
-       (-> (processor arg-map)
+       (-> (p/do (processor arg-map))
+           (p/timeout timeout)
            (p/then (fn [v] [nil v]))
            (p/catch (fn [e] [(wrap-error-cljs e arg-map err-ctx) nil])))
        (catch :default e
@@ -287,7 +288,7 @@
         node (-> (get graph node-key) (dissoc :gx/failure))
         node-state (:gx/state node)
         signal-def (get node signal-key)
-        {:gx/keys [processor props-schema resolved-props props]} signal-def
+        {:gx/keys [processor props-schema resolved-props props timeout]} signal-def
         ;; take deps from another signal of node if current signal has deps-from
         ;; and does not have resolved props
         {:gx/keys [resolved-props resolved-props-fn deps]}
@@ -305,7 +306,8 @@
         failed-dep-node-keys (->> {:graph dep-nodes}
                                   (failures)
                                   (filter second)
-                                  (map first))]
+                                  (map first))
+        timeout (or timeout 10000)]
     (with-err-ctx {:node-contents (node-key initial-graph)}
       (cond
         (or ;; signal isn't defined for this state transition
@@ -337,7 +339,8 @@
                                          :value (:gx/value node)
                                          :state (:gx/state node)
                                          :instance (:gx/instance node)}
-                                        #?(:cljs err-ctx)))
+                                        #?(:cljs err-ctx)
+                                        timeout))
                       new-value (or (:gx/value result) result)]
                 (if-let [e (or validate-error error)]
                   (assoc node :gx/failure e)

--- a/src/k16/gx/beta/errors.cljc
+++ b/src/k16/gx/beta/errors.cljc
@@ -4,6 +4,13 @@
                          node-contents signal-key
                          causes])
 
+(defn get-real-cause
+  [e]
+  (loop [e e]
+    (if-let [c (ex-cause e)]
+      (recur c)
+      e)))
+
 (def ^:dynamic *err-ctx*
   "Error context is used for creating/throwing exceptions with contextual data"
   (map->ErrorContext {:error-type :general :causes []}))

--- a/src/k16/gx/beta/schema.cljc
+++ b/src/k16/gx/beta/schema.cljc
@@ -37,6 +37,7 @@
   [:map
    gx-props
    [:gx/processor ifn?]
+   [:gx/timeout {:optional true} number?]
    [:gx/props-schema {:optional true} any?]
    [:gx/resolved-props-fn {:optional true} [:maybe fn?]]
    [:gx/deps {:optional true} coll?]
@@ -46,7 +47,7 @@
   [:map
    ;; top level props
    gx-props
-   [:gx/component {:optional true }any?]
+   [:gx/component {:optional true } any?]
    [:gx/signal-mapping {:optional true} [:map-of keyword? keyword?]]
    [:gx/state {:optional true} keyword?]
    [:gx/failure {:optional true} any?]


### PR DESCRIPTION
Signal processors can take arbitrarilly long and may hang if there is some failure that results in the promise never resolving.

This can make it hard to debug what components are failing both in production and in development environments.

This change adds a processor timeout configuration option and gives it a default of 10000ms.